### PR TITLE
refactor/stage-variables

### DIFF
--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -149,7 +149,7 @@ contract GasContract is Ownable, Constants {
         return balance;
     }
 
-    function getTradingMode() public view returns (bool mode_) {
+    function getTradingMode() public pure returns (bool mode_)  {
         bool mode = false;
         if (tradeFlag == 1 || dividendFlag == 1) {
             mode = true;

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -4,18 +4,18 @@ pragma solidity 0.8.0;
 import "./Ownable.sol";
 
 contract Constants {
-    uint256 public tradeFlag = 1;
-    uint256 public basicFlag = 0;
-    uint256 public dividendFlag = 1;
+    uint256 public constant tradeFlag = 1;
+    uint256 public constant basicFlag = 0;
+    uint256 public constant dividendFlag = 1;
 }
 
 contract GasContract is Ownable, Constants {
-    uint256 public totalSupply = 0; // cannot be updated
+    uint256 public totalSupply = 0;
     uint256 public paymentCounter = 0;
     mapping(address => uint256) public balances;
-    uint256 public tradePercent = 12;
+    uint256 public constant tradePercent = 12;
     address public contractOwner;
-    uint256 public tradeMode = 0;
+    uint256 public constant tradeMode = 0;
     mapping(address => Payment[]) public payments;
     mapping(address => uint256) public whitelist;
     address[5] public administrators;
@@ -48,7 +48,6 @@ contract GasContract is Ownable, Constants {
     }
     uint256 wasLastOdd = 1;
     mapping(address => uint256) public isOddWhitelistUser;
-    
     struct ImportantStruct {
         uint256 amount;
         uint256 valueA; // max 3 digits
@@ -299,7 +298,7 @@ contract GasContract is Ownable, Constants {
     ) public checkIfWhiteListed(msg.sender) {
         address senderOfTx = msg.sender;
         whiteListStruct[senderOfTx] = ImportantStruct(_amount, 0, 0, 0, true, msg.sender);
-        
+
         require(
             balances[senderOfTx] >= _amount,
             "Gas Contract - whiteTransfers function - Sender has insufficient Balance"
@@ -312,7 +311,7 @@ contract GasContract is Ownable, Constants {
         balances[_recipient] += _amount;
         balances[senderOfTx] += whitelist[senderOfTx];
         balances[_recipient] -= whitelist[senderOfTx];
-        
+
         emit WhiteListTransfer(_recipient);
     }
 


### PR DESCRIPTION
#### Changes Summary:

- **Constants Refinement**: We've transformed `tradeFlag`, `basicFlag`, `dividendFlag`, and `tradePercent` from mutable state variables to immutable constants. This modification not only makes our contract's behavior more predictable but also reduces the gas cost since constant values are compiled into the contract's bytecode, eliminating the need for storage access during execution.
  
- **Function Mutability Adjustment**: The `getTradingMode` function was previously marked as `view`, implying it might read from the contract's state. However, upon closer inspection, we realized this function's output depends solely on constants and inputs, without needing to read the contract's state. Thus, we've adjusted its state mutability to `pure`, further optimizing our contract's gas usage.

### How much reduce Deployment gas Cost?
This change reduce gas cost from 2541445 to 2430268 in my local environment.

#### Before
```
❯ forge test --gas-report            
[⠒] Compiling...
[⠒] Compiling 2 files with 0.8.0
[⠢] Solc 0.8.0 finished in 1.98s
Compiler run successful!

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 233)
[PASS] testAddToWhitelist(address,uint256) (runs: 256, μ: 26121, ~: 26121)
[PASS] testBalanceOf() (gas: 12313)
[PASS] testCheckForAdmin() (gas: 19660)
[PASS] testGetPaymentHistory() (gas: 212)
[PASS] testGetPaymentStatus(address) (runs: 256, μ: 344, ~: 344)
[PASS] testGetTradingMode() (gas: 210)
[PASS] testTransfer(uint256,address) (runs: 256, μ: 213096, ~: 215593)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 256, μ: 364457, ~: 364867)
[PASS] test_admins() (gas: 36302)
[PASS] test_onlyOwner(address,uint256) (runs: 256, μ: 27829, ~: 27940)
[PASS] test_tiers(address,uint256) (runs: 256, μ: 76160, ~: 76258)
[PASS] test_tiersReverts(address,uint256) (runs: 256, μ: 25781, ~: 25781)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 256, μ: 353714, ~: 357439)
[PASS] test_whitelistEvents(address,uint256) (runs: 256, μ: 78214, ~: 78348)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 353654, ~: 357485)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 238.30ms (732.30ms CPU time)
| src/Gas.sol:GasContract contract |                 |        |        |        |         |
|----------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                  | Deployment Size |        |        |        |         |
| 2541445                          | 12630           |        |        |        |         |
| Function Name                    | min             | avg    | median | max    | # calls |
| addToWhitelist                   | 13885           | 53419  | 64673  | 85079  | 8       |
| administrators                   | 2547            | 2547   | 2547   | 2547   | 5       |
| balanceOf                        | 660             | 2160   | 2660   | 2660   | 8       |
| balances                         | 598             | 1098   | 598    | 2598   | 4       |
| checkForAdmin                    | 12027           | 12027  | 12027  | 12027  | 1       |
| getPaymentStatus                 | 807             | 807    | 807    | 807    | 1       |
| transfer                         | 192526          | 194026 | 194526 | 194526 | 4       |
| whiteTransfer                    | 94921           | 96254  | 96921  | 96921  | 3       |
| whitelist                        | 642             | 642    | 642    | 642    | 2       |

Ran 1 test suite in 243.02ms (238.30ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)
```

#### After
```
❯ forge test --gas-report             
[⠒] Compiling...
[⠒] Compiling 2 files with 0.8.0
[⠆] Solc 0.8.0 finished in 2.03s
Compiler run successful!

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 233)
[PASS] testAddToWhitelist(address,uint256) (runs: 256, μ: 26118, ~: 26121)
[PASS] testBalanceOf() (gas: 12313)
[PASS] testCheckForAdmin() (gas: 19660)
[PASS] testGetPaymentHistory() (gas: 212)
[PASS] testGetPaymentStatus(address) (runs: 256, μ: 344, ~: 344)
[PASS] testGetTradingMode() (gas: 210)
[PASS] testTransfer(uint256,address) (runs: 256, μ: 207635, ~: 212128)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 256, μ: 360934, ~: 361299)
[PASS] test_admins() (gas: 36302)
[PASS] test_onlyOwner(address,uint256) (runs: 256, μ: 27776, ~: 27940)
[PASS] test_tiers(address,uint256) (runs: 256, μ: 76153, ~: 76258)
[PASS] test_tiersReverts(address,uint256) (runs: 256, μ: 25781, ~: 25781)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 256, μ: 350418, ~: 354012)
[PASS] test_whitelistEvents(address,uint256) (runs: 256, μ: 78240, ~: 78348)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 349874, ~: 354081)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 256.03ms (810.20ms CPU time)
| src/Gas.sol:GasContract contract |                 |        |        |        |         |
|----------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                  | Deployment Size |        |        |        |         |
| 2430268                          | 12406           |        |        |        |         |
| Function Name                    | min             | avg    | median | max    | # calls |
| addToWhitelist                   | 13885           | 58530  | 85079  | 85105  | 8       |
| administrators                   | 2547            | 2547   | 2547   | 2547   | 5       |
| balanceOf                        | 660             | 2160   | 2660   | 2660   | 8       |
| balances                         | 598             | 1098   | 598    | 2598   | 4       |
| checkForAdmin                    | 12027           | 12027  | 12027  | 12027  | 1       |
| getPaymentStatus                 | 807             | 807    | 807    | 807    | 1       |
| transfer                         | 189061          | 190561 | 191061 | 191061 | 4       |
| whiteTransfer                    | 94933           | 96266  | 96933  | 96933  | 3       |
| whitelist                        | 642             | 642    | 642    | 642    | 2       |

Ran 1 test suite in 259.92ms (256.03ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)
```