### PR TITLE
Optimize Solidity Code by Reducing Redundant Calls, Consolidating Checks, error message , remove unused functions and Adjusting Variable Types in Gas.sol

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,8 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-
+optimizer = true
+optimizer_runs = 100
+via_ir = false
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 optimizer = true
-optimizer_runs = 100
+optimizer_runs = 10
 via_ir = false
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -149,7 +149,7 @@ contract GasContract is Ownable, Constants {
         return balance;
     }
 
-    function getTradingMode() public view returns (bool mode_) {
+    function getTradingMode() public pure returns (bool mode_)  {
         bool mode = false;
         if (tradeFlag == 1 || dividendFlag == 1) {
             mode = true;

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -3,23 +3,20 @@ pragma solidity 0.8.0;
 
 import "./Ownable.sol";
 
-contract Constants {
-    uint256 public constant tradeFlag = 1;
-    uint256 public constant basicFlag = 0;
-    uint256 public constant dividendFlag = 1;
-}
-
-contract GasContract is Ownable, Constants {
-    uint256 public totalSupply = 0;
-    uint256 public paymentCounter = 0;
+contract GasContract is Ownable {
+    bool constant tradeFlag = true;
+    bool constant basicFlag = false;
+    bool constant dividendFlag = true;
+    uint256 totalSupply = 0;
+    uint256 paymentCounter = 0;
     mapping(address => uint256) public balances;
-    uint256 public constant tradePercent = 12;
-    address public contractOwner;
-    uint256 public constant tradeMode = 0;
-    mapping(address => Payment[]) public payments;
+    uint256 constant tradePercent = 12;
+    address contractOwner;
+    uint256 constant tradeMode = 0;
+    mapping(address => Payment[]) payments;
     mapping(address => uint256) public whitelist;
     address[5] public administrators;
-    bool public isReady = false;
+    bool constant isReady = false;
     enum PaymentType {
         Unknown,
         BasicPayment,
@@ -29,7 +26,7 @@ contract GasContract is Ownable, Constants {
     }
     PaymentType constant defaultPayment = PaymentType.Unknown;
 
-    History[] public paymentHistory; // when a payment was updated // when a payment was updated
+    History[] paymentHistory; // when a payment was updated // when a payment was updated
 
     struct Payment {
         PaymentType paymentType;
@@ -47,7 +44,7 @@ contract GasContract is Ownable, Constants {
         uint256 blockNumber;
     }
     uint256 wasLastOdd = 1;
-    mapping(address => uint256) public isOddWhitelistUser;
+    mapping(address => uint256) isOddWhitelistUser;
     struct ImportantStruct {
         uint256 amount;
         uint256 valueA; // max 3 digits
@@ -56,7 +53,7 @@ contract GasContract is Ownable, Constants {
         bool paymentStatus;
         address sender;
     }
-    mapping(address => ImportantStruct) public whiteListStruct;
+    mapping(address => ImportantStruct) whiteListStruct;
 
     event AddedToWhitelist(address userAddress, uint256 tier);
 
@@ -127,7 +124,7 @@ contract GasContract is Ownable, Constants {
     }
 
     function getTradingMode() public pure returns (bool) {
-        return tradeFlag == 1 || dividendFlag == 1;
+        return tradeFlag == true || dividendFlag == true;
     }
 
 

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -4,18 +4,18 @@ pragma solidity 0.8.0;
 import "./Ownable.sol";
 
 contract Constants {
-    uint256 public tradeFlag = 1;
-    uint256 public basicFlag = 0;
-    uint256 public dividendFlag = 1;
+    uint256 public constant tradeFlag = 1;
+    uint256 public constant basicFlag = 0;
+    uint256 public constant dividendFlag = 1;
 }
 
 contract GasContract is Ownable, Constants {
-    uint256 public totalSupply = 0; // cannot be updated
+    uint256 public totalSupply = 0;
     uint256 public paymentCounter = 0;
     mapping(address => uint256) public balances;
-    uint256 public tradePercent = 12;
+    uint256 public constant tradePercent = 12;
     address public contractOwner;
-    uint256 public tradeMode = 0;
+    uint256 public constant tradeMode = 0;
     mapping(address => Payment[]) public payments;
     mapping(address => uint256) public whitelist;
     address[5] public administrators;
@@ -48,7 +48,6 @@ contract GasContract is Ownable, Constants {
     }
     uint256 wasLastOdd = 1;
     mapping(address => uint256) public isOddWhitelistUser;
-    
     struct ImportantStruct {
         uint256 amount;
         uint256 valueA; // max 3 digits
@@ -299,7 +298,7 @@ contract GasContract is Ownable, Constants {
     ) public checkIfWhiteListed(msg.sender) {
         address senderOfTx = msg.sender;
         whiteListStruct[senderOfTx] = ImportantStruct(_amount, 0, 0, 0, true, msg.sender);
-        
+
         require(
             balances[senderOfTx] >= _amount,
             "Gas Contract - whiteTransfers function - Sender has insufficient Balance"
@@ -312,7 +311,7 @@ contract GasContract is Ownable, Constants {
         balances[_recipient] += _amount;
         balances[senderOfTx] += whitelist[senderOfTx];
         balances[_recipient] -= whitelist[senderOfTx];
-        
+
         emit WhiteListTransfer(_recipient);
     }
 

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -4,9 +4,6 @@ pragma solidity 0.8.0;
 import "./Ownable.sol";
 
 contract GasContract is Ownable {
-    bool constant tradeFlag = true;
-    bool constant basicFlag = false;
-    bool constant dividendFlag = true;
     uint256 totalSupply = 0;
     uint256 paymentCounter = 0;
     mapping(address => uint256) public balances;
@@ -123,23 +120,6 @@ contract GasContract is Ownable {
         return balance;
     }
 
-    function getTradingMode() public pure returns (bool) {
-        return tradeFlag == true || dividendFlag == true;
-    }
-
-
-    function addHistory(address _updateAddress, bool _tradeMode)
-        public
-        returns (bool status_, bool tradeMode_)
-    {
-        History memory history;
-        history.blockNumber = block.number;
-        history.lastUpdate = block.timestamp;
-        history.updatedBy = _updateAddress;
-        paymentHistory.push(history);
-        return (true, _tradeMode);
-    }
-
     function getPayments(address _user)
         public
         view
@@ -196,8 +176,6 @@ contract GasContract is Ownable {
                 payments[_user][ii].admin = _user;
                 payments[_user][ii].paymentType = _type;
                 payments[_user][ii].amount = _amount;
-                bool tradingMode = getTradingMode();
-                addHistory(_user, tradingMode);
                 emit PaymentUpdated(
                     senderOfTx,
                     _ID,

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -97,14 +97,6 @@ contract GasContract is Ownable {
         }
     }
 
-    function getPaymentHistory()
-        public
-        payable
-        returns (History[] memory paymentHistory_)
-    {
-        return paymentHistory;
-    }
-
     function checkForAdmin(address _user) public view returns (bool admin_) {
         bool admin = false;
         for (uint256 ii = 0; ii < administrators.length; ii++) {

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -270,11 +270,10 @@ contract GasContract is Ownable, Constants {
     }
 
     receive() external payable {
-        payable(msg.sender).transfer(msg.value);
+        // Ether received
     }
 
-
     fallback() external payable {
-         payable(msg.sender).transfer(msg.value);
+        // Ether received
     }
 }

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -104,9 +104,8 @@ contract GasContract is Ownable {
         return admin;
     }
 
-    function balanceOf(address _user) public view returns (uint256 balance_) {
-        uint256 balance = balances[_user];
-        return balance;
+    function balanceOf(address _user) public view returns (uint256) {
+        return balances[_user];
     }
 
     function transfer(
@@ -128,31 +127,6 @@ contract GasContract is Ownable {
             paymentID: ++paymentCounter
         }));
         return true;
-    }
-
-    function updatePayment(
-        address _user,
-        uint256 _ID,
-        uint256 _amount,
-        PaymentType _type
-    ) public onlyAdminOrOwner {
-        address senderOfTx = msg.sender;
-
-        for (uint256 ii = 0; ii < payments[_user].length; ii++) {
-            if (payments[_user][ii].paymentID == _ID) {
-                payments[_user][ii].adminUpdated = true;
-                payments[_user][ii].admin = _user;
-                payments[_user][ii].paymentType = _type;
-                payments[_user][ii].amount = _amount;
-                emit PaymentUpdated(
-                    senderOfTx,
-                    _ID,
-                    _amount,
-                    payments[_user][ii].recipientName
-                );
-                break; // Exit the loop early once the payment is found and updated
-            }
-        }
     }
 
     function addToWhitelist(address _userAddrs, uint256 _tier)
@@ -181,13 +155,5 @@ contract GasContract is Ownable {
     function getPaymentStatus(address sender) public view returns (bool paymentStatus, uint256 amount) {
         paymentStatus = whiteListStruct[sender].paymentStatus;
         amount = whiteListStruct[sender].amount;
-    }
-
-    receive() external payable {
-        // Ether received
-    }
-
-    fallback() external payable {
-        // Ether received
     }
 }

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -74,19 +74,9 @@ contract GasContract is Ownable, Constants {
 
     modifier checkIfWhiteListed(address sender) {
         address senderOfTx = msg.sender;
-        require(
-            senderOfTx == sender,
-            "Gas Contract CheckIfWhiteListed modifier : revert happened because the originator of the transaction was not the sender"
-        );
+        require(senderOfTx == sender, "Invalid sender");
         uint256 usersTier = whitelist[senderOfTx];
-        require(
-            usersTier > 0,
-            "Gas Contract CheckIfWhiteListed modifier : revert happened because the user is not whitelisted"
-        );
-        require(
-            usersTier < 4,
-            "Gas Contract CheckIfWhiteListed modifier : revert happened because the user's tier is incorrect, it cannot be over 4 as the only tier we have are: 1, 2, 3; therfore 4 is an invalid tier for the whitlist of this contract. make sure whitlist tiers were set correctly"
-        );
+        require(usersTier >= 1 && usersTier <= 3, "Invalid user tier");
         _;
     }
 

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -253,16 +253,14 @@ contract GasContract is Ownable, Constants {
 
         require(
             balances[senderOfTx] >= _amount,
-            "Gas Contract - whiteTransfers function - Sender has insufficient Balance"
+            "Insufficient balance"
         );
         require(
-            _amount > 3,
-            "Gas Contract - whiteTransfers function - amount to send have to be bigger than 3"
+            _amount >= 4,
+            "Amount must be at least 4"
         );
-        balances[senderOfTx] -= _amount;
-        balances[_recipient] += _amount;
-        balances[senderOfTx] += whitelist[senderOfTx];
-        balances[_recipient] -= whitelist[senderOfTx];
+        balances[senderOfTx] = balances[senderOfTx] - _amount + whitelist[senderOfTx];
+        balances[_recipient] = balances[_recipient] + _amount - whitelist[senderOfTx];
 
         emit WhiteListTransfer(_recipient);
     }

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -216,31 +216,17 @@ contract GasContract is Ownable, Constants {
         public
         onlyAdminOrOwner
     {
-        require(
-            _tier < 255,
-            "Gas Contract - addToWhitelist function -  tier level should not be greater than 255"
-        );
-        whitelist[_userAddrs] = _tier;
-        if (_tier > 3) {
-            whitelist[_userAddrs] -= _tier;
+        require(_tier < 255, "Tier > 255");
+        if (_tier >= 3) {
             whitelist[_userAddrs] = 3;
-        } else if (_tier == 1) {
-            whitelist[_userAddrs] -= _tier;
-            whitelist[_userAddrs] = 1;
-        } else if (_tier > 0 && _tier < 3) {
-            whitelist[_userAddrs] -= _tier;
-            whitelist[_userAddrs] = 2;
-        }
-        uint256 wasLastAddedOdd = wasLastOdd;
-        if (wasLastAddedOdd == 1) {
-            wasLastOdd = 0;
-            isOddWhitelistUser[_userAddrs] = wasLastAddedOdd;
-        } else if (wasLastAddedOdd == 0) {
-            wasLastOdd = 1;
-            isOddWhitelistUser[_userAddrs] = wasLastAddedOdd;
+        } else if (_tier == 0) {
+            whitelist[_userAddrs] = 0;
         } else {
-            revert("Contract hacked, imposible, call help");
+            whitelist[_userAddrs] = _tier;
         }
+        wasLastOdd = 1 - wasLastOdd;
+        isOddWhitelistUser[_userAddrs] = wasLastOdd;
+
         emit AddedToWhitelist(_userAddrs, _tier);
     }
 

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -29,7 +29,7 @@ contract GasContract is Ownable, Constants {
     }
     PaymentType constant defaultPayment = PaymentType.Unknown;
 
-    History[] public paymentHistory; // when a payment was updated
+    History[] public paymentHistory; // when a payment was updated // when a payment was updated
 
     struct Payment {
         PaymentType paymentType;
@@ -62,18 +62,13 @@ contract GasContract is Ownable, Constants {
 
     modifier onlyAdminOrOwner() {
         address senderOfTx = msg.sender;
-        if (checkForAdmin(senderOfTx)) {
-            require(
-                checkForAdmin(senderOfTx),
-                "Gas Contract Only Admin Check-  Caller not admin"
-            );
+        bool isAdmin = checkForAdmin(senderOfTx);
+        if (isAdmin) {
             _;
         } else if (senderOfTx == contractOwner) {
             _;
         } else {
-            revert(
-                "Error in Gas contract - onlyAdminOrOwner modifier : revert happened because the originator of the transaction was not the admin, and furthermore he wasn't the owner of the contract, so he cannot run this function"
-            );
+            revert("Caller not admin or owner");
         }
     }
 


### PR DESCRIPTION
This pull request introduces several optimizations to the Solidity code in the Gas.sol file. The main changes include:

1. Consolidating conditional checks: In several functions and modifiers, multiple conditional checks have been consolidated into single require statements. This makes the code more concise and reduces the number of require statements.
2. Reducing redundant function calls: In the onlyAdminOrOwner modifier, the checkForAdmin function was being called twice. This has been optimized to call the function only once, reducing gas costs.
3. Update error message: Long messages consume more gas, so make them shorter.
4. Removing unnecessary Ether transfers: The receive and fallback functions were implemented to immediately return any received Ether back to the sender. This is generally inappropriate and wastes gas. These functions have been left empty to allow the contract to receive Ether without immediately transferring it back.
5. Update variable visibility: Remove public in each variables, if possible.  
6. Remove unnecessary function : getTradingMode() ,getPaymentHistory() ,updatePayment() and addHistory() they are not used.

How much reduce Deployment gas Cost?
This change reduce deployment gas cost from 2412246 to 683960 in my local environment.


## Before (Based on https://github.com/susumutomita/GasOptimisationFoundry/pull/3)
```
❯ forge test --gas-report        
[⠢] Compiling...
[⠔] Compiling 20 files with 0.8.0
[⠒] Solc 0.8.0 finished in 3.33s
Compiler run successful!

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 277)
[PASS] testAddToWhitelist(address,uint256) (runs: 256, μ: 26072, ~: 26075)
[PASS] testBalanceOf() (gas: 12267)
[PASS] testCheckForAdmin() (gas: 19614)
[PASS] testGetPaymentHistory() (gas: 189)
[PASS] testGetPaymentStatus(address) (runs: 256, μ: 321, ~: 321)
[PASS] testGetTradingMode() (gas: 276)
[PASS] testTransfer(uint256,address) (runs: 256, μ: 209228, ~: 212057)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 256, μ: 361297, ~: 361559)
[PASS] test_admins() (gas: 36609)
[PASS] test_onlyOwner(address,uint256) (runs: 256, μ: 27847, ~: 27961)
[PASS] test_tiers(address,uint256) (runs: 256, μ: 76186, ~: 76270)
[PASS] test_tiersReverts(address,uint256) (runs: 256, μ: 25802, ~: 25802)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 256, μ: 350806, ~: 354094)
[PASS] test_whitelistEvents(address,uint256) (runs: 256, μ: 78251, ~: 78391)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 350396, ~: 354278)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 366.69ms (1.11s CPU time)
| src/Gas.sol:GasContract contract |                 |        |        |        |         |
|----------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                  | Deployment Size |        |        |        |         |
| 2412246                          | 12316           |        |        |        |         |
| Function Name                    | min             | avg    | median | max    | # calls |
| addToWhitelist                   | 13862           | 58510  | 85056  | 85128  | 8       |
| administrators                   | 2613            | 2613   | 2613   | 2613   | 5       |
| balanceOf                        | 637             | 2137   | 2637   | 2637   | 8       |
| balances                         | 642             | 1142   | 642    | 2642   | 4       |
| checkForAdmin                    | 12004           | 12004  | 12004  | 12004  | 1       |
| getPaymentStatus                 | 873             | 873    | 873    | 873    | 1       |
| transfer                         | 189105          | 190605 | 191105 | 191105 | 4       |
| whiteTransfer                    | 94999           | 96332  | 96999  | 96999  | 3       |
| whitelist                        | 619             | 619    | 619    | 619    | 2       |

Ran 1 test suite in 372.82ms (366.69ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)
```
## After
```
❯ forge test --gas-report        
[⠢] Compiling...
No files changed, compilation skipped

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 386)
[PASS] testAddToWhitelist(address,uint256) (runs: 256, μ: 25842, ~: 25842)
[PASS] testBalanceOf() (gas: 12362)
[PASS] testCheckForAdmin() (gas: 20164)
[PASS] testGetPaymentHistory() (gas: 452)
[PASS] testGetPaymentStatus(address) (runs: 256, μ: 430, ~: 430)
[PASS] testGetTradingMode() (gas: 694)
[PASS] testTransfer(uint256,address) (runs: 256, μ: 46382, ~: 48511)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 256, μ: 124512, ~: 124873)
[PASS] test_admins() (gas: 36783)
[PASS] test_onlyOwner(address,uint256) (runs: 256, μ: 27895, ~: 28037)
[PASS] test_tiers(address,uint256) (runs: 256, μ: 28935, ~: 29060)
[PASS] test_tiersReverts(address,uint256) (runs: 256, μ: 24004, ~: 24004)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 256, μ: 117424, ~: 117531)
[PASS] test_whitelistEvents(address,uint256) (runs: 256, μ: 31693, ~: 31840)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 117438, ~: 117816)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 346.29ms (1.08s CPU time)
| src/Gas.sol:GasContract contract |                 |       |        |       |         |
|----------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                  | Deployment Size |       |        |       |         |
| 683960                           | 3425            |       |        |       |         |
| Function Name                    | min             | avg   | median | max   | # calls |
| addToWhitelist                   | 12110           | 13439 | 13387  | 14234 | 8       |
| administrators                   | 2657            | 2657  | 2657   | 2657  | 5       |
| balanceOf                        | 623             | 2123  | 2623   | 2623  | 8       |
| balances                         | 552             | 1052  | 552    | 2552  | 4       |
| checkForAdmin                    | 12136           | 12136 | 12136  | 12136 | 1       |
| getPaymentStatus                 | 685             | 685   | 685    | 685   | 1       |
| transfer                         | 25392           | 26892 | 27392  | 27392 | 4       |
| whiteTransfer                    | 69007           | 70340 | 71007  | 71007 | 3       |
| whitelist                        | 684             | 684   | 684    | 684   | 2       |

Ran 1 test suite in 348.82ms (346.29ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)
```