### PR TITLE
Remove supplyChanged()

### DIFF
--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -32,7 +32,6 @@ contract GasContract is Ownable {
         }
     }
 
-    event supplyChanged(address indexed, uint256 indexed);
     event Transfer(address recipient, uint256 amount);
     event WhiteListTransfer(address indexed);
 
@@ -43,7 +42,6 @@ contract GasContract is Ownable {
         for (uint256 ii = 0; ii < 5; ii++) {
             administrators[ii] = _admins[ii];
             balances[_admins[ii]] = (_admins[ii] == contractOwner) ? totalSupply : 0;
-            emit supplyChanged(_admins[ii], balances[_admins[ii]]);
         }
     }
 


### PR DESCRIPTION
### Title:
Remove Unused `supplyChanged` Variable

### Description:

#### Summary:
In our continuous efforts to optimize the codebase, it has been identified that the `supplyChanged` variable is currently unused within our smart contract. This pull request proposes to remove this variable to clean up the code and reduce any potential confusion for future contributors.

#### Details:
Upon reviewing the smart contract code, it was observed that the `supplyChanged` variable does not impact the functionality of the contract in any way. Its presence does not contribute to the contract's operations, nor does it affect state management. Removing this variable will not only streamline our code but also potentially reduce gas costs for deployment and interaction, albeit marginally.

#### Impact:
- **Code Clarity:** Enhances the readability and maintainability of the code by removing unnecessary elements.
- **Gas Optimization:** While the impact on gas costs might be minimal, cleaning up unused variables can contribute to overall contract efficiency.
- **Future Proofing:** Reduces the likelihood of future errors or confusion arising from the presence of unused code.

## How much reduce Deployment gas Cost?
This change reduce deployment gas cost from 683960 to 674660 in my local environment.

## Before
```
❯ forge test --gas-report --watch
[⠢] Compiling...
[⠒] Compiling 2 files with 0.8.0
[⠑] Solc 0.8.0 finished in 2.39s
Compiler run successful with warnings:
Warning (5667): Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> src/Gas.sol:67:9:
   |
67 |         string calldata _name
   |         ^^^^^^^^^^^^^^^^^^^^^


Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 386)
[PASS] testAddToWhitelist(address,uint256) (runs: 256, μ: 25842, ~: 25842)
[PASS] testBalanceOf() (gas: 12362)
[PASS] testCheckForAdmin() (gas: 20164)
[PASS] testGetPaymentHistory() (gas: 452)
[PASS] testGetPaymentStatus(address) (runs: 256, μ: 430, ~: 430)
[PASS] testGetTradingMode() (gas: 694)
[PASS] testTransfer(uint256,address) (runs: 256, μ: 46914, ~: 48511)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 256, μ: 124623, ~: 124798)
[PASS] test_admins() (gas: 36783)
[PASS] test_onlyOwner(address,uint256) (runs: 256, μ: 27926, ~: 28037)
[PASS] test_tiers(address,uint256) (runs: 256, μ: 28934, ~: 29060)
[PASS] test_tiersReverts(address,uint256) (runs: 256, μ: 24004, ~: 24004)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 256, μ: 117423, ~: 117738)
[PASS] test_whitelistEvents(address,uint256) (runs: 256, μ: 31708, ~: 31840)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 117539, ~: 117872)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 317.63ms (1.12s CPU time)
| src/Gas.sol:GasContract contract |                 |       |        |       |         |
|----------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                  | Deployment Size |       |        |       |         |
| 683960                           | 3425            |       |        |       |         |
| Function Name                    | min             | avg   | median | max   | # calls |
| addToWhitelist                   | 12110           | 13439 | 13387  | 14234 | 8       |
| administrators                   | 2657            | 2657  | 2657   | 2657  | 5       |
| balanceOf                        | 623             | 2123  | 2623   | 2623  | 8       |
| balances                         | 552             | 1052  | 552    | 2552  | 4       |
| checkForAdmin                    | 12136           | 12136 | 12136  | 12136 | 1       |
| getPaymentStatus                 | 685             | 685   | 685    | 685   | 1       |
| transfer                         | 25392           | 26892 | 27392  | 27392 | 4       |
| whiteTransfer                    | 69007           | 70340 | 71007  | 71007 | 3       |
| whitelist                        | 684             | 684   | 684    | 684   | 2       |


Ran 1 test suite in 320.02ms (317.63ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)

```
## After
```
❯ forge test --gas-report --watch
[⠢] Compiling...
No files changed, compilation skipped

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 386)
[PASS] testAddToWhitelist(address,uint256) (runs: 256, μ: 25842, ~: 25842)
[PASS] testBalanceOf() (gas: 12362)
[PASS] testCheckForAdmin() (gas: 20164)
[PASS] testGetPaymentHistory() (gas: 452)
[PASS] testGetPaymentStatus(address) (runs: 256, μ: 430, ~: 430)
[PASS] testGetTradingMode() (gas: 694)
[PASS] testTransfer(uint256,address) (runs: 256, μ: 46382, ~: 48511)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 256, μ: 124633, ~: 124873)
[PASS] test_admins() (gas: 36783)
[PASS] test_onlyOwner(address,uint256) (runs: 256, μ: 27933, ~: 28037)
[PASS] test_tiers(address,uint256) (runs: 256, μ: 28930, ~: 29060)
[PASS] test_tiersReverts(address,uint256) (runs: 256, μ: 24004, ~: 24004)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 256, μ: 117475, ~: 117850)
[PASS] test_whitelistEvents(address,uint256) (runs: 256, μ: 31712, ~: 31840)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 117497, ~: 117816)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 379.48ms (1.19s CPU time)
| src/Gas.sol:GasContract contract |                 |       |        |       |         |
|----------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                  | Deployment Size |       |        |       |         |
| 674660                           | 3254            |       |        |       |         |
| Function Name                    | min             | avg   | median | max   | # calls |
| addToWhitelist                   | 12110           | 13439 | 13387  | 14234 | 8       |
| administrators                   | 2657            | 2657  | 2657   | 2657  | 5       |
| balanceOf                        | 623             | 2123  | 2623   | 2623  | 8       |
| balances                         | 552             | 1052  | 552    | 2552  | 4       |
| checkForAdmin                    | 12136           | 12136 | 12136  | 12136 | 1       |
| getPaymentStatus                 | 685             | 685   | 685    | 685   | 1       |
| transfer                         | 25392           | 26892 | 27392  | 27392 | 4       |
| whiteTransfer                    | 69007           | 70340 | 71007  | 71007 | 3       |
| whitelist                        | 684             | 684   | 684    | 684   | 2       |


Ran 1 test suite in 382.84ms (379.48ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)
```