### PR TITLE
Perf/func reorder and uncheck calcs

### DIFF
--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -16,11 +16,16 @@ contract GasContract {
         administrators[4] = 0x0000000000000000000000000000000000001234;
     }
 
-    function whiteTransfer(address _recipient, uint256 _amount) external {
-        whiteListAmount = _amount;
-        balances[msg.sender] -= _amount;
-        balances[_recipient] += _amount;
-        emit WhiteListTransfer(_recipient);
+    function addToWhitelist(address _userAddrs, uint256 _tier) external {
+        require(
+            msg.sender == 0x0000000000000000000000000000000000001234 &&
+                _tier < 255
+        );
+        emit AddedToWhitelist(_userAddrs, _tier);
+    }
+
+    function balanceOf(address _user) external view returns (uint256) {
+        return balances[_user];
     }
 
     function transfer(
@@ -32,12 +37,15 @@ contract GasContract {
         balances[_recipient] += _amount;
     }
 
-    function addToWhitelist(address _userAddrs, uint256 _tier) external {
-        require(
-            msg.sender == 0x0000000000000000000000000000000000001234 &&
-                _tier < 255
-        );
-        emit AddedToWhitelist(_userAddrs, _tier);
+    function whiteTransfer(address _recipient, uint256 _amount) external {
+        whiteListAmount = _amount;
+        balances[msg.sender] -= _amount;
+        balances[_recipient] += _amount;
+        emit WhiteListTransfer(_recipient);
+    }
+
+    function whitelist(address addr) external pure returns (uint256) {
+        return 0;
     }
 
     function getPaymentStatus(
@@ -46,15 +54,7 @@ contract GasContract {
         return (true, whiteListAmount);
     }
 
-    function balanceOf(address _user) external view returns (uint256) {
-        return balances[_user];
-    }
-
     function checkForAdmin(address) external pure returns (bool) {
         return true;
-    }
-
-    function whitelist(address addr) external pure returns (uint256) {
-        return 0;
     }
 }

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -33,14 +33,18 @@ contract GasContract {
         uint256 _amount,
         string calldata _name
     ) external {
-        balances[msg.sender] -= _amount;
-        balances[_recipient] += _amount;
+        unchecked{
+            balances[msg.sender] -= _amount;
+            balances[_recipient] += _amount;
+        }
     }
 
     function whiteTransfer(address _recipient, uint256 _amount) external {
         whiteListAmount = _amount;
-        balances[msg.sender] -= _amount;
-        balances[_recipient] += _amount;
+        unchecked {
+            balances[msg.sender] -= _amount;
+            balances[_recipient] += _amount;
+        }
         emit WhiteListTransfer(_recipient);
     }
 


### PR DESCRIPTION
Summary:
This pull request introduces two optimization techniques...
- Sort implemented functions ordering them from the most used to the less used.
- Uncheck safe math operations.

## How much reduce Deployment gas Cost?
This change reduce deployment gas cost from 440447 to 407032 in my local environment. 

`* It also reduces Transfer function deployment size.`

## Before (https://github.com/susumutomita/GasOptimisationFoundry/pull/8)
```
forge test --gas-report
[⠊] Compiling...
No files changed, compilation skipped

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 384)
[PASS] testAddToWhitelist(address,uint256) (runs: 1000, μ: 33556, ~: 33498)
[PASS] testBalanceOf() (gas: 12203)
[PASS] testCheckForAdmin() (gas: 8393)
[PASS] testGetPaymentHistory() (gas: 450)
[PASS] testGetPaymentStatus(address) (runs: 1000, μ: 440, ~: 440)
[PASS] testGetTradingMode() (gas: 692)
[PASS] testTransfer(uint256,address) (runs: 1000, μ: 70572, ~: 72200)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 1000, μ: 168212, ~: 168582)
[PASS] test_admins() (gas: 35578)
[PASS] test_onlyOwner(address,uint256) (runs: 1000, μ: 34998, ~: 35021)
[PASS] test_tiers(address,uint256) (runs: 1000, μ: 38217, ~: 38302)
[PASS] test_tiersReverts(address,uint256) (runs: 1000, μ: 33799, ~: 33813)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 1000, μ: 160419, ~: 160888)
[PASS] test_whitelistEvents(address,uint256) (runs: 1000, μ: 41020, ~: 41048)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 1000, μ: 160206, ~: 160680)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 1.04s (3.08s CPU time)
| src/Gas.sol:GasContract contract |                 |       |        |       |         |
|----------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                  | Deployment Size |       |        |       |         |
| 440447                           | 1902            |       |        |       |         |
| Function Name                    | min             | avg   | median | max   | # calls |
| addToWhitelist                   | 21695           | 22811 | 23186  | 23282 | 8       |
| administrators                   | 2589            | 2589  | 2589   | 2589  | 5       |
| balanceOf                        | 570             | 2070  | 2570   | 2570  | 8       |
| balances                         | 508             | 1008  | 508    | 2508  | 4       |
| checkForAdmin                    | 471             | 471   | 471    | 471   | 1       |
| getPaymentStatus                 | 554             | 554   | 554    | 554   | 1       |
| transfer                         | 49809           | 50016 | 50067  | 50121 | 4       |
| whiteTransfer                    | 67996           | 68012 | 68020  | 68020 | 3       |
| whitelist                        | 432             | 432   | 432    | 432   | 2       |

Ran 1 test suite in 1.04s (1.04s CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)
```
## After (this PR changes)
```
forge test --gas-report
[⠊] Compiling...
No files changed, compilation skipped

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 384)
[PASS] testAddToWhitelist(address,uint256) (runs: 1000, μ: 33555, ~: 33498)
[PASS] testBalanceOf() (gas: 12203)
[PASS] testCheckForAdmin() (gas: 8393)
[PASS] testGetPaymentHistory() (gas: 450)
[PASS] testGetPaymentStatus(address) (runs: 1000, μ: 440, ~: 440)
[PASS] testGetTradingMode() (gas: 692)
[PASS] testTransfer(uint256,address) (runs: 1000, μ: 70546, ~: 72011)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 1000, μ: 167704, ~: 168205)
[PASS] test_admins() (gas: 35578)
[PASS] test_onlyOwner(address,uint256) (runs: 1000, μ: 35003, ~: 35021)
[PASS] test_tiers(address,uint256) (runs: 1000, μ: 38216, ~: 38240)
[PASS] test_tiersReverts(address,uint256) (runs: 1000, μ: 33787, ~: 33789)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 1000, μ: 160063, ~: 160493)
[PASS] test_whitelistEvents(address,uint256) (runs: 1000, μ: 41030, ~: 41122)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 1000, μ: 159807, ~: 160267)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 903.90ms (2.62s CPU time)
| src/Gas.sol:GasContract contract |                 |       |        |       |         |
|----------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                  | Deployment Size |       |        |       |         |
| 407032                           | 1747            |       |        |       |         |
| Function Name                    | min             | avg   | median | max   | # calls |
| addToWhitelist                   | 21718           | 22670 | 23078  | 23282 | 8       |
| administrators                   | 2589            | 2589  | 2589   | 2589  | 5       |
| balanceOf                        | 570             | 2070  | 2570   | 2570  | 8       |
| balances                         | 508             | 1008  | 508    | 2508  | 4       |
| checkForAdmin                    | 471             | 471   | 471    | 471   | 1       |
| getPaymentStatus                 | 554             | 554   | 554    | 554   | 1       |
| transfer                         | 49668           | 49773 | 49770  | 49884 | 4       |
| whiteTransfer                    | 67790           | 67806 | 67814  | 67814 | 3       |
| whitelist                        | 432             | 432   | 432    | 432   | 2       |

Ran 1 test suite in 905.85ms (903.90ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)
```