### PR TITLE
update administrators

### DIFF
--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -4,16 +4,31 @@ pragma solidity 0.8.24;
 contract GasContract {
     uint256 private whiteListAmount;
     mapping(address => uint256) public balances;
-    address[5] public administrators;
     event WhiteListTransfer(address indexed);
     event AddedToWhitelist(address userAddress, uint256 tier);
     constructor(address[] memory _admins, uint256 _totalSupply) {
         balances[0x0000000000000000000000000000000000001234] = 1000000000;
-        administrators[0] = 0x3243Ed9fdCDE2345890DDEAf6b083CA4cF0F68f2;
-        administrators[1] = 0x2b263f55Bf2125159Ce8Ec2Bb575C649f822ab46;
-        administrators[2] = 0x0eD94Bc8435F3189966a49Ca1358a55d871FC3Bf;
-        administrators[3] = 0xeadb3d065f8d15cc05e92594523516aD36d1c834;
-        administrators[4] = 0x0000000000000000000000000000000000001234;
+    }
+
+    function administrators(uint index) public pure returns (address admin) {
+        assembly {
+            switch index
+            case 0 {
+                admin := 0x3243Ed9fdCDE2345890DDEAf6b083CA4cF0F68f2
+            }
+            case 1 {
+                admin := 0x2b263f55Bf2125159Ce8Ec2Bb575C649f822ab46
+            }
+            case 2 {
+                admin := 0x0eD94Bc8435F3189966a49Ca1358a55d871FC3Bf
+            }
+            case 3 {
+                admin := 0xeadb3d065f8d15cc05e92594523516aD36d1c834
+            }
+            case 4 {
+                admin := 0x1234
+            }
+        }
     }
 
     function addToWhitelist(address _userAddrs, uint256 _tier) external {


### PR DESCRIPTION
Just Note for me.

❯ make test
forge test --gas-report
[⠊] Compiling...
No files changed, compilation skipped

Ran 16 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddHistory() (gas: 384)
[PASS] testAddToWhitelist(address,uint256) (runs: 1000, μ: 11908, ~: 11914)
[PASS] testBalanceOf() (gas: 12203)
[PASS] testCheckForAdmin() (gas: 8393)
[PASS] testGetPaymentHistory() (gas: 450)
[PASS] testGetPaymentStatus(address) (runs: 1000, μ: 440, ~: 440)
[PASS] testGetTradingMode() (gas: 692)
[PASS] testTransfer(uint256,address) (runs: 1000, μ: 44369, ~: 46163)
[PASS] testWhiteTranferAmountUpdate(address,address,uint256,string,uint256) (runs: 1000, μ: 83825, ~: 84253)
[PASS] test_admins() (gas: 25277)
[PASS] test_onlyOwner(address,uint256) (runs: 1000, μ: 13509, ~: 13641)
[PASS] test_tiers(address,uint256) (runs: 1000, μ: 16722, ~: 16860)
[PASS] test_tiersReverts(address,uint256) (runs: 1000, μ: 12169, ~: 12169)
[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 1000, μ: 78189, ~: 78595)
[PASS] test_whitelistEvents(address,uint256) (runs: 1000, μ: 19524, ~: 19668)
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 1000, μ: 78020, ~: 78378)
Suite result: ok. 16 passed; 0 failed; 0 skipped; finished in 649.01ms (2.04s CPU time)
| src/Gas.sol:GasContract contract |                 |       |        |       |         |
|----------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                  | Deployment Size |       |        |       |         |
| 245836                           | 1740            |       |        |       |         |
| Function Name                    | min             | avg   | median | max   | # calls |
| addToWhitelist                   | 339             | 1197  | 1710   | 1710  | 8       |
| administrators                   | 487             | 528   | 531    | 564   | 5       |
| balanceOf                        | 570             | 2070  | 2570   | 2570  | 8       |
| balances                         | 508             | 1008  | 508    | 2508  | 4       |
| checkForAdmin                    | 471             | 471   | 471    | 471   | 1       |
| getPaymentStatus                 | 554             | 554   | 554    | 554   | 1       |
| transfer                         | 1120            | 19645 | 25820  | 25820 | 4       |
| whiteTransfer                    | 44206           | 45539 | 46206  | 46206 | 3       |
| whitelist                        | 432             | 432   | 432    | 432   | 2       |

Ran 1 test suite in 650.34ms (649.01ms CPU time): 16 tests passed, 0 failed, 0 skipped (16 total tests)